### PR TITLE
update to mathcomp-1.16.0

### DIFF
--- a/3rdparty/ALEA/Ccpo.v
+++ b/3rdparty/ALEA/Ccpo.v
@@ -703,7 +703,7 @@ Qed.
        Ole := fun n m : nat => (n <= m)%nat}.
 Next Obligation.
 abstract (apply Build_Order; intros; try lia; auto with arith;
-          red; intros; apply le_trans with y; auto).
+          red; intros; apply Nat.le_trans with y; auto).
 Defined.
 
 Lemma le_Ole : forall n m, ((n <= m)%nat)-> n <= m.

--- a/3rdparty/ALEA/Misc.v
+++ b/3rdparty/ALEA/Misc.v
@@ -21,20 +21,13 @@ Require Import Coq.Classes.Morphisms.
 
 Local Open Scope signature_scope.
 
-
-(* Should be in standard library Arith.EqNat.beq_nat. *)
-Lemma beq_nat_neq: forall x y : nat, x <> y -> false = beq_nat x y.
-Proof.
-  induction x;induction y;simpl;auto.
-Qed.
-
 Lemma if_beq_nat_nat_eq_dec : forall A (x y:nat) (a b:A),
-  (if beq_nat x y then a else b) = if eq_nat_dec x y then a else b.
+  (if Nat.eqb x y then a else b) = if eq_nat_dec x y then a else b.
 Proof.
   intros A x y a b.
-  destruct (eq_nat_dec x y);intros;subst.
-  rewrite <- beq_nat_refl;trivial.
-  rewrite <- beq_nat_neq;auto.
+  destruct (eq_nat_dec x y) as [H|H];intros;subst.
+  - rewrite Nat.eqb_refl. reflexivity.
+  - apply Nat.eqb_neq in H. rewrite H. reflexivity.
 Qed.
 
 Definition ifte A (test:bool) (thn els:A) := if test then thn else els.

--- a/theories/Basic/combclass.v
+++ b/theories/Basic/combclass.v
@@ -245,7 +245,7 @@ Proof using HPTi Hpart.
 move=> HPx; have:= HPx; rewrite /enum_union => /Hpart H.
 rewrite count_flatten -2!map_comp.
 pose ix := @Sub TI PI TPI (FI x) H.
-rewrite (eq_map (f2 := fun i => i == ix : nat)); first last.
+rewrite (eq_map (g := fun i => i == ix : nat)); first last.
   move=> i /=.
   case: (altP (i =P ix)) => [-> {i} | Hneq].
   - rewrite count_map /=.
@@ -282,7 +282,7 @@ Lemma card_unionE : #|union_finType| = \sum_(i : TPI) #|TPi i|.
 Proof using.
 rewrite cardE -(size_map val) /= enum_unionE.
 rewrite /enum_union size_flatten /shape -map_comp.
-rewrite (eq_map (f2 := fun i => #|TPi i|)); first last.
+rewrite (eq_map (g := fun i => #|TPi i|)); first last.
   by move=> i; rewrite /= size_map cardE.
 by rewrite sumn_mapE big_enum.
 Qed.

--- a/theories/Combi/Dyckword.v
+++ b/theories/Combi/Dyckword.v
@@ -423,11 +423,11 @@ have {}Hmin n : (n <= cut)%N -> height (take n tl) >= 0.
 have HDL : (take cut tl) \is a Dyck_word.
   apply/Dyck_wordP; split; last by rewrite Hbalcut.
   rewrite height_take_leq => n.
-  by rewrite size_take Hcut => Hncut; rewrite take_take // Hmin.
+  by rewrite size_take Hcut => Hncut; rewrite take_takel // Hmin.
 have HDR : (drop cut.+1 tl) \is a Dyck_word.
   apply/Dyck_wordP; split => [n|].
   - rewrite take_drop height_drop.
-    rewrite take_take ?ltnS ?leq_addl //.
+    rewrite take_takel ?ltnS ?leq_addl //.
     rewrite Hf1 height_rcons /= Hbalcut sub0r /=.
     have := Hpos ((n + cut.+1).+1)%N.
     by rewrite /= height_simpl /= addrC.
@@ -626,7 +626,7 @@ Lemma exists_minh : exists i : nat, height (take i w) == minh.
 Proof.
 rewrite /height minhE.
 have : (#|'I_(size w).+1| > 0)%N by rewrite card_ord.
-set F := BIG_F; case/(eq_bigmax F) => [[i Hi]]; rewrite {}/F /= => Hmax.
+set F := BIG_F; case/(bigop.eq_bigmax F) => [[i Hi]]; rewrite {}/F /= => Hmax.
 case: (leqP (count_mem {{ (take i w)) (count_mem }} (take i w))) => [Hle |/ltnW].
 - by exists i; rewrite -eqr_opp opprK opprB (subzn Hle) Hmax.
 - rewrite -subn_eq0 => /eqP Heq; move: Hmax; rewrite Heq => ->.
@@ -728,9 +728,9 @@ apply/Dyck_wordP; rewrite height_take_leq; split => [n|].
 - have -> : size (take (size w).-1 (rot pfminh w)) = (size w).-1.
     rewrite size_take size_rot /=.
     by case: w Hbal1 => //= w0 tlw _; rewrite ltnSn.
-  move => Hn; rewrite take_take // /rot take_cat size_drop.
+  move => Hn; rewrite take_takel // /rot take_cat size_drop.
   case: ltnP => [{}Hn| Hnpf].
-  + rewrite take_drop height_drop take_take ?leq_addl // subr_ge0.
+  + rewrite take_drop height_drop take_takel ?leq_addl // subr_ge0.
     by rewrite pfminhP minhP.
   + have {Hnpf} : (n - (size w - pfminh) < pfminh)%N.
       rewrite subnBA ?pfminh_size // addnC -subnBA ?leq_subr; first last.
@@ -740,7 +740,7 @@ apply/Dyck_wordP; rewrite height_take_leq; split => [n|].
       rewrite [(_ - n)%N]subSn // subSS ltnS.
       exact: leq_subr.
     move: (n - (size w - pfminh))%N => {}n {}Hn.
-    rewrite height_simpl take_take; last exact: ltnW.
+    rewrite height_simpl take_takel; last exact: ltnW.
     move: Hbal1; rewrite -{1}(cat_take_drop pfminh w) height_simpl => /eqP.
     rewrite -subr_eq0 opprK [height _ + _]addrC -addrA addr_eq0 => /eqP ->.
     rewrite addrC subr_ge0 lez_addr1.
@@ -776,7 +776,7 @@ apply/esym/pfminhE => [|i|i].
   rewrite subSn // ltnS ltnn subnn take0 cats0 ltnS.
   rewrite -(leq_add2r rt) subnK //.
   case: leqP => Hi.
-  + rewrite take_drop !height_drop take_take ?leq_addl //.
+  + rewrite take_drop !height_drop take_takel ?leq_addl //.
     rewrite ler_sub_addr subrK -cats1 takel_cat //.
     rewrite !height_simpl /= addr0.
     move: HDyck => /Dyck_wordP [H1 ->].
@@ -784,7 +784,7 @@ apply/esym/pfminhE => [|i|i].
     by rewrite -oppr_ge0 opprK.
   + rewrite height_simpl addrC -ler_subl_addr subrr.
     case: (leqP (i - (size w - rt).+1) rt) => [H | /ltnW H].
-    * rewrite take_take // -cats1 takel_cat; last exact: leq_trans H Hrt.
+    * rewrite take_takel // -cats1 takel_cat; last exact: leq_trans H Hrt.
       by move: HDyck => /Dyck_wordP [->].
     * rewrite take_oversize ?size_take ?size_rcons ?ltnS ?Hrt //.
       rewrite -cats1 takel_cat //.
@@ -792,7 +792,7 @@ apply/esym/pfminhE => [|i|i].
 - rewrite subSn // ltnS => Hi.
   rewrite /rot !take_cat !size_drop !size_rcons.
   rewrite subSn // ltnS ltnn subnn take0 cats0 ltnS Hi.
-  rewrite take_drop !height_drop take_take ?leq_addl //.
+  rewrite take_drop !height_drop take_takel ?leq_addl //.
   rewrite ltr_subl_addl addrC subrK.
   rewrite height_rcons /=; move: HDyck => /Dyck_wordP [_ ->].
   move: Hi; rewrite -(leq_add2r rt) subnK // => Hi.
@@ -961,7 +961,7 @@ Lemma bal_of_DyckP rt w :
 Proof.
 case: w => [w _] /= Hsz H H0.
 rewrite /rot take_cat size_drop size_rcons subKn; last exact: (leq_trans Hsz).
-rewrite ltnNge Hsz !height_simpl /= take_take subSn // addrC.
+rewrite ltnNge Hsz !height_simpl /= take_takel subSn // addrC.
 have : (size w - rt < size (rcons w }}))%N by rewrite size_rcons ltnS leq_subr.
 move=>/(take_nth {{)/(congr1 height); rewrite !height_simpl => /eqP.
 rewrite H /= -subr_eq opprK => /eqP <-.
@@ -1001,7 +1001,7 @@ have {bD Hnth} -> : rcons bD }} = rotr rt (rcons D }}).
   rewrite {}/bD /rotr/rot take_cat size_drop subKn; first last.
     by rewrite size_rcons; apply: (leq_trans Hsz).
   rewrite ltnNge Hsz /= rcons_cat; congr (_ ++ _).
-  rewrite size_rcons take_take ?subSn //.
+  rewrite size_rcons take_takel ?subSn //.
   by rewrite (take_nth {{) ?size_rcons ?ltnS ?leq_subr // Hnth.
 case: rt Hsz => [_ | rt Hsz].
   rewrite /rotr subn0 rot_size -{1}(rot0 (rcons D }})) pfminh_rrw //.
@@ -1042,7 +1042,7 @@ apply/andP/imsetP => /= [[/eqP ubal /eqP Huw] | [v /=]].
     have := Dyck_of_balK ubal; rewrite Huw.
     move=> /(congr1 val)/=; rewrite /rotr/rot.
     rewrite take_cat size_drop subKn ?size_rcons //; last exact: ltnW.
-    rewrite ltnNge -ltnS Hpfminh /= take_take ?subSn //.
+    rewrite ltnNge -ltnS Hpfminh /= take_takel ?subSn //.
     move/(congr1 height)/esym; rewrite ubal height_simpl height_drop.
     rewrite (take_nth {{) ?size_rcons ?ltnS ?leq_subr //.
     rewrite !height_simpl /= opprD [(- _ + _)%R]addrC.

--- a/theories/Combi/Yamanouchi.v
+++ b/theories/Combi/Yamanouchi.v
@@ -372,7 +372,7 @@ move=> ev Hev Hpart [/= | y0 y] /=.
   by have -> : [::] == ev = false by move: Hev; case ev.
 move => /andP [] /andP [] _ Hyam /eqP Htmp; subst ev.
 rewrite count_flatten -map_comp.
-rewrite (eq_map (f2 := fun i => i == y0 : nat)); first last.
+rewrite (eq_map (g := fun i => i == y0 : nat)); first last.
   move=> i /=; rewrite count_map /=.
   case (altP (i =P y0)) => [Heq | /negbTE Hneq].
   - subst i; rewrite (eq_count (a2 := xpred1 y)); first last.
@@ -483,7 +483,7 @@ Lemma enum_yamnE :
   map val (enum {:yamn}) = flatten [seq enum_yameval p | p <- enum_partn n].
 Proof using.
 rewrite enum_unionE /=; congr flatten.
-rewrite [LHS](eq_map (f2 := enum_yameval \o val)).
+rewrite [LHS](eq_map (g := enum_yameval \o val)).
 - by rewrite map_comp enum_intpartnE.
 - by move=> i /=; rewrite enum_yamevalE.
 Qed.

--- a/theories/Combi/bintree.v
+++ b/theories/Combi/bintree.v
@@ -733,7 +733,7 @@ rewrite -rev_path /= last_rcons belast_rcons.
 have -> : rev (flipsz t2 :: p) =
           [seq flipsz t | t <- rcons [seq flipsz t' | t' <- rev p] t2].
   rewrite map_rev -rev_cons map_rev /=.
-  rewrite -map_comp (eq_map (f2 := id)); last by move=> x /=; rewrite flipszK.
+  rewrite -map_comp (eq_map (g := id)); last by move=> x /=; rewrite flipszK.
   by rewrite map_id.
 rewrite (map_path (b := pred0)
                   (e' := (fun t t' => trval t' \in rotations t))); first last.

--- a/theories/Combi/composition.v
+++ b/theories/Combi/composition.v
@@ -194,7 +194,7 @@ have /negbTE -> : n != 0.
   move: s0neq0; apply contra => /eqP Hn0.
   by move: Hsum; rewrite Hn0 addn_eq0 => /andP [/eqP ->].
 rewrite count_flatten -map_comp.
-rewrite (eq_map (f2 := fun i => i == s0 : nat)); first last.
+rewrite (eq_map (g := fun i => i == s0 : nat)); first last.
   move=> /= i; rewrite count_map /=.
   case (altP (i =P s0)) => [Heq | /negbTE Hneq].
   - subst s0; rewrite (eq_count (a2 := xpred1 s)); first last.

--- a/theories/Combi/partition.v
+++ b/theories/Combi/partition.v
@@ -1213,7 +1213,7 @@ elim: sz sm mx => [//= | sz IHsz] /= sm mx Hmx.
   by move=> p /and4P [Hhead/nilP -> /= /eqP <-].
 case=> [| p0 p] //=; first by rewrite andbF.
 move=> /and5P [Hp0]; rewrite eqSS=> /eqP Hsz /eqP Hsm Hhead Hpart.
-rewrite count_flatten -map_comp (eq_map (f2 := fun i => i == p0 : nat)); first last.
+rewrite count_flatten -map_comp (eq_map (g := fun i => i == p0 : nat)); first last.
   move=> i /=; rewrite count_map /=.
   case (altP (i =P p0)) => [Heq | /negbTE Hneq].
   - subst p0; rewrite (eq_count (a2 := xpred1 p)); first last.
@@ -1294,7 +1294,7 @@ case: (altP (size p =P 0)) => Hsize.
   suff -> : sumn (map (fun=> 0) _) = 0 by rewrite addn0.
   by move=> T; elim => [//= |l0 l /= ->].
 - rewrite /= add0n count_flatten -map_comp.
-  rewrite (eq_map (f2 := fun i => i == size p : nat)); first last.
+  rewrite (eq_map (g := fun i => i == size p : nat)); first last.
     move=> i /=; rewrite enum_partnsE /=.
     by rewrite Hsum Hpart !andbT eq_sym.
   by rewrite sumn_pred1_iota add1n ltnS lt0n Hsize /= -(eqP Hsum) size_part.
@@ -1789,7 +1789,7 @@ Lemma size_enum_partnsk sm sz mx :
 Proof.
 elim: sz sm mx => [ [] | sz IHsz] //= sm mx.
 rewrite size_flatten /shape -[1]addn0 iotaDl -!map_comp.
-rewrite (eq_map (f2 := fun i => intpartnsk_nb (sm - i.+1) sz i.+1)); first last.
+rewrite (eq_map (g := fun i => intpartnsk_nb (sm - i.+1) sz i.+1)); first last.
   by move=> i /=; rewrite size_map IHsz.
 elim: (minn sm mx) => [//= | n IHn].
 by rewrite -{1}[n.+1]addn1 iotaD add0n map_cat sumn_cat IHn /= addn0.

--- a/theories/Combi/skewpart.v
+++ b/theories/Combi/skewpart.v
@@ -1214,7 +1214,7 @@ case: startrem => start [|rem]// Heq /(_ (ltn0Sn _)) lesmin [<- _].
 have:= lesmin; rewrite leq_min => /andP [lespos lessz].
 rewrite /add_ribbon_on !sumn_cat /= sumn_mapS.
 rewrite size_drop size_take -/(minn _ _).
-rewrite sumn_nseq mul1n -(take_take lespos) !addnA.
+rewrite sumn_nseq mul1n -(take_takel _ lespos) !addnA.
 rewrite ![_ + sumn (drop start _)]addnAC -sumn_cat cat_take_drop.
 rewrite ![_ + (_ - start) + _]addnAC addnBA //.
 rewrite minnE -addnA (subnKC (leq_subr _ _)) // 2![_ + pos]addnAC.

--- a/theories/Combi/skewtab.v
+++ b/theories/Combi/skewtab.v
@@ -513,7 +513,7 @@ Lemma shape_join_tab s t :
   ([seq r.1 + r.2 | r <- zip (pad 0 (size t) (shape s)) (shape t)])%N.
 Proof using .
 rewrite /shape /join_tab -map_comp.
-rewrite (eq_map (f2 := (fun p => p.1 + p.2) \o
+rewrite (eq_map (g := (fun p => p.1 + p.2) \o
                          (fun p => (size p.1, size p.2)))); first last.
   by move=> [a b] /=; rewrite size_cat.
 rewrite map_comp; congr map.

--- a/theories/Combi/stdtab.v
+++ b/theories/Combi/stdtab.v
@@ -785,7 +785,7 @@ Proof using. by rewrite /conj_tab size_mkseq. Qed.
 Lemma shape_conj_tab t : shape (conj_tab t) = conj_part (shape t).
 Proof using.
 rewrite /conj_tab /shape -map_comp.
-rewrite (eq_map (f2 := fun i =>
+rewrite (eq_map (g := fun i =>
                          (nth 0 (conj_part [seq size i | i <- t]) i))); first last.
   by move => i /=; rewrite size_mkseq.
 by rewrite -/(shape _) -/(mkseq _ _); apply: mkseq_nth.

--- a/theories/Combi/vectNK.v
+++ b/theories/Combi/vectNK.v
@@ -82,7 +82,7 @@ case: s => [|s0 s]; first by rewrite vect_n_kP /= => /andP [_].
 move/flatten_mapP; rewrite -/vect_n_k => [] [i].
 rewrite mem_iota [iota _ _]lock add0n => Hs0.
 move/mapP => [t Ht [H1 H2]]; subst i; subst t.
-rewrite (eq_map (f2 := (fun i : nat => i == s0 : nat))).
+rewrite (eq_map (g := (fun i : nat => i == s0 : nat))).
   by unlock; rewrite sumn_pred1_iota add0n Hs0.
 move=> i; rewrite /= count_map /=.
 rewrite (eq_count (a2 := fun t => (i == s0) && (s == t))); first last.

--- a/theories/HookFormula/hook.v
+++ b/theories/HookFormula/hook.v
@@ -1247,7 +1247,7 @@ rewrite [RHS]mulrC -[RHS]mulr1; congr (_ * _ * _).
   have swap_inj : injective swap by apply (can_inj (g := swap)) => [] [r c].
   rewrite -[RHS]big_filter; set F := (X in \prod_(i <- _) X i).
   rewrite -[X in \prod_(i <- X) _]map_id.
-  rewrite (eq_map (f2 := swap \o swap)); last by move=> [r c].
+  rewrite (eq_map (g := swap \o swap)); last by move=> [r c].
   rewrite map_comp big_map.
   transitivity (\prod_(i <- enum_box_in p' |
                        (i.1 != Alpha) && (i.2 == Beta))  F (swap i)).

--- a/theories/LRrule/Greene.v
+++ b/theories/LRrule/Greene.v
@@ -117,7 +117,7 @@ elim: n l => [|n IHn] [| l0 l].
 - by move=> _; have:= ltn_ord l0; rewrite ltn0.
 - rewrite (eq_filter (a2 := pred0)); first by rewrite filter_pred0.
   by move=> i /=; rewrite in_nil.
-- rewrite (enum_ordS n) /=.
+- rewrite (enum_ordSl n) /=.
   case: l0 => [[/=| l0] Hl0].
   + have -> : Ordinal Hl0 = ord0 by exact: val_inj.
     move/unlift_seqE => [l1] [/IHn {IHn} <- Hl].
@@ -339,13 +339,13 @@ Proof using.
 rewrite extractIE.
 elim: n wt P => [//= | n IHn].
 - by rewrite enum0.
-- case/tupleP=> w0 w P; rewrite enum_ordS /=.
+- case/tupleP=> w0 w P; rewrite enum_ordSl /=.
   set lft := map (lift ord0) _.
   suff : [seq tnth [tuple of w0 :: w] i | i <- lft & P i] =
          mask [seq P i | i <- lft] w.
     by case: (P ord0) => /= ->.
   rewrite /lft {lft} filter_map -map_comp -map_comp /= -(IHn w _) /=.
-  by rewrite (eq_map (f2 := tnth w));
+  by rewrite (eq_map (g := tnth w));
     last by move=> i /=; rewrite !(tnth_nth inh).
 Qed.
 
@@ -355,7 +355,7 @@ Proof using.
 rewrite !extractmaskE; case: wt => w /= _.
 elim: n w P1 P2 => [//= | n IHn] w P1 P2 H; first by rewrite enum0.
 case: w => [//= | w0 w]; first by rewrite !mask0.
-rewrite enum_ordS /= -map_comp -map_comp.
+rewrite enum_ordSl /= -map_comp -map_comp.
 case (boolP (P1 ord0)) => H1.
 - by rewrite (H ord0 H1) /= eq_refl; apply: IHn => i /=; apply: H.
 - case (boolP (P2 ord0)) => H2.
@@ -586,7 +586,7 @@ Lemma enumIMN : enum 'I_(M + N) = map lsh (enum 'I_M) ++ map rsh (enum 'I_N).
 Proof using.
 apply: (inj_map (@ord_inj (M + N))).
 rewrite map_cat -2!map_comp !val_enum_ord.
-rewrite (eq_map (f2 := (addn M) \o val)); last by [].
+rewrite (eq_map (g := (addn M) \o val)); last by [].
 by rewrite map_comp !val_enum_ord -iotaDl [M + 0]addnC iotaD.
 Qed.
 
@@ -836,7 +836,7 @@ apply/and4P; split.
   rewrite -(revK (extractpred (in_tuple (rev u)) _)) rev_sorted.
   rewrite !extractIE -map_rev -filter_rev.
   rewrite (eq_map
-             (f2 := fun i => tnth (in_tuple u) (cast_ord (size_rev u) (rev_ord i))));
+             (g := fun i => tnth (in_tuple u) (cast_ord (size_rev u) (rev_ord i))));
     first last.
     move=> i /=.
     by rewrite !(tnth_nth inh) /= nth_rev ?{2}(size_rev u) // -(size_rev u).
@@ -862,7 +862,7 @@ apply/and4P; split.
   rewrite map_rev val_enum_ord (nth_iota _ _ Hi) add0n.
   rewrite nth_rev size_map size_enum_ord; last by rewrite size_rev.
   rewrite [X in X - _](size_rev).
-  rewrite (eq_map (f2 := (fun i => (size u - i.+1)) \o val)); first last.
+  rewrite (eq_map (g := (fun i => (size u - i.+1)) \o val)); first last.
     by move=> j /=; rewrite {1}size_rev.
   rewrite map_comp val_enum_ord size_rev.
   have Hu : size u - i.+1 < size u by rewrite -subn_gt0 subKn.
@@ -939,7 +939,7 @@ Lemma shcol_cards sh :
 Proof using.
 elim: sh => [//= | s0 sh IHsh] /= /andP [Hhead Hpart].
 rewrite -map_comp.
-rewrite (eq_map (f2 := fun i : 'I_(_) => (nth 0 (conj_part sh) i).+1)); first last.
+rewrite (eq_map (g := fun i : 'I_(_) => (nth 0 (conj_part sh) i).+1)); first last.
   move=> i; rewrite /= cardsU.
   rewrite cards1 imset_comp card_imset; last exact: cast_ord_inj.
   rewrite card_imset; last exact: lshift_inj.
@@ -970,12 +970,12 @@ elim: sh s0 Hhead Hpart {IHsh} => [//= | s1 sh IHsh] /=.
     rewrite nth_nseq Hi (nth_map (Ordinal Hi)); last by rewrite size_enum_ord.
     by rewrite nth_nil.
   + case => [//= | s0]; rewrite ltnS => /IHl <- {IHl}.
-    rewrite (eq_map (f2 := (fun i => (nth 0 (l0 :: l) i).+1) \o val)) //.
+    rewrite (eq_map (g := (fun i => (nth 0 (l0 :: l) i).+1) \o val)) //.
     rewrite map_comp val_enum_ord /=.
     rewrite -[1]addn0 iotaDl -map_comp.
     pose f := fun i => (nth 0 l i).+1.
-    rewrite (eq_map (f2 := f)) //; apply esym.
-    rewrite (eq_map (f2 := f \o nat_of_ord)) //.
+    rewrite (eq_map (g := f)) //; apply esym.
+    rewrite (eq_map (g := f \o nat_of_ord)) //.
     by rewrite [map _ (enum _)]map_comp val_enum_ord /=.
 Qed.
 
@@ -1210,7 +1210,7 @@ rewrite enumIsize_to_word filter_cat map_cat -[RHS]cat0s; congr (_ ++ _).
 - rewrite (eq_in_filter (a2 := predT)); first last.
     by move=> i /= /mapP [j _ -> {i}]; rewrite imset_f.
   rewrite filter_predT -map_comp.
-  rewrite (eq_map (f2 := nth inh t0 \o val)); first last.
+  rewrite (eq_map (g := nth inh t0 \o val)); first last.
   + move=> i /=; rewrite (tnth_nth inh).
     rewrite {1 2}(to_word_cons t0 t) /= nth_cat.
     rewrite -{2}[size (to_word t)]addn0 ltn_add2l /=.
@@ -1237,10 +1237,10 @@ have /eq_map -> /= :
 rewrite {f} /= enumIsize_to_word filter_cat map_cat -[RHS]cats0; congr (_ ++ _).
 - rewrite (nth_map set0) /=; last by rewrite size_shrows size_map.
   rewrite filter_map /= -map_comp.
-  set f2 := (X in _ = map X _); rewrite (eq_map (f2 := f2)); first last.
-    rewrite /f2 {f2} => j /=; rewrite !(tnth_nth inh) /=.
+  set g := (X in _ = map X _); rewrite (eq_map (g := g)); first last.
+    rewrite /g {g} => j /=; rewrite !(tnth_nth inh) /=.
     by rewrite to_word_cons nth_cat ltn_ord.
-  congr (map f2 _) => {f2}.
+  congr (map g _) => {g}.
   apply: eq_filter => j /=; rewrite mem_imset; last exact lshift_recP.
   rewrite (nth_map set0) /cast_set_tab //=.
   by rewrite size_shrows size_map.
@@ -1287,13 +1287,13 @@ rewrite nth_enum_ord //= {13}to_word_cons.
 rewrite nth_ord_ltn map_cat mask_cat; last by rewrite 2!size_map size_enum_ord.
 rewrite -map_comp.
 set fr := (X in rcons (mask (map X _) _)).
-rewrite (eq_map (f2 := fr)); first last.
+rewrite (eq_map (g := fr)); first last.
   move=> j /=; rewrite inE in_set1 lrshift_recF /=.
   by rewrite (mem_imset _ _ lshift_recP).
 rewrite -map_comp.
-set f2 := (X in _ ++ mask (map X _) _).
-have {f2} /eq_map -> : f2 =1 mem ([set (Ordinal Hi)]).
-  move=> j; rewrite /f2 /= !inE.
+set g := (X in _ ++ mask (map X _) _).
+have {g} /eq_map -> : g =1 mem ([set (Ordinal Hi)]).
+  move=> j; rewrite /g /= !inE.
   rewrite [X in _ || X](_ : _ = false); first last.
     by apply/imsetP => [[k _] /eqP];  rewrite eq_sym lrshift_recF.
   rewrite orbF.

--- a/theories/LRrule/Greene_inv.v
+++ b/theories/LRrule/Greene_inv.v
@@ -231,7 +231,7 @@ Lemma rev_enum :
 Proof using.
 apply: (inj_map val_inj); rewrite /=.
 rewrite val_enum_ord map_rev -map_comp.
-rewrite [map (_ \o _) _](eq_map (f2 := (fun i => size w - i.+1) \o val)) //.
+rewrite [map (_ \o _) _](eq_map (g := (fun i => size w - i.+1) \o val)) //.
 rewrite map_comp val_enum_ord size_rev.
 apply: (eq_from_nth (x0 := 0)); first by rewrite size_rev size_map.
 move=> i; rewrite size_iota => Hi.

--- a/theories/LRrule/freeSchur.v
+++ b/theories/LRrule/freeSchur.v
@@ -81,7 +81,7 @@ Invariance with the choice of Q1 and Q2:
 Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import ssrfun ssrbool eqtype ssrnat seq fintype.
 From mathcomp Require Import order tuple finfun bigop finset ssralg.
-From SsrMultinomials Require Import ssrcomplements freeg mpoly.
+From mathcomp.multinomials Require Import ssrcomplements freeg mpoly.
 
 Require Import tools ordtype partition Yamanouchi std tableau stdtab.
 Require Import Schensted congr plactic stdplact Yam_plact Greene_inv shuffle.

--- a/theories/LRrule/implem.v
+++ b/theories/LRrule/implem.v
@@ -30,7 +30,7 @@ The following lemma assert that LRcoeff agrees with LRyamtab_list
 Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype.
 From mathcomp Require Import tuple finfun finset bigop path order.
-From SsrMultinomials Require Import mpoly.
+From mathcomp.multinomials Require Import mpoly.
 
 Require Import tools combclass partition Yamanouchi ordtype tableau.
 Require Import skewtab Schur_mpoly freeSchur therule.

--- a/theories/LRrule/implem.v
+++ b/theories/LRrule/implem.v
@@ -195,7 +195,7 @@ elim: outer innev inner sh0 row0 => [//= | out0 out IHout] /= innev inner sh0 ro
 rewrite size_flatten /shape !map_flatten sumn_flatten.
 rewrite tsumnE; congr (sumn _).
 rewrite -[X in [seq sumn i | i <- X]]map_comp.
-rewrite (eq_map (f2 := map (fun row =>
+rewrite (eq_map (g := map (fun row =>
                LRyamtab_count_rec row.2 (behead inner) out (head 0 inner) row.1))).
 - by rewrite [RHS]map_comp (eq_map tsumnE) -!map_comp; exact: eq_map.
 - move=> s /=; rewrite -map_comp; apply eq_map => {s} [] [row sh] /=.
@@ -554,9 +554,9 @@ elim: row base shape => [| l0 row IHrow] [| b0 base] //= shape.
 move/eqP; rewrite eqSS => /eqP Hsize Hdom Hisrow Hskew Hincl.
 rewrite count_flatten -map_comp.
 set f1 := (X in map X); set rec := (X in map _ X).
-pose f2 := nat_of_bool \o (pred1 row) \o (@fst (seq nat) (seq nat)).
-have : {in rec, f1 =1 f2}.
-  rewrite /rec /f1 /f2 {rec f1 f2} => [[r shr]] /= Hr.
+pose g := nat_of_bool \o (pred1 row) \o (@fst (seq nat) (seq nat)).
+have : {in rec, f1 =1 g}.
+  rewrite /rec /f1 /g {rec f1 g} => [[r shr]] /= Hr.
   rewrite count_map.
   case: (altP (r =P row)) => [Hrow | /negbTE Hneq] /=.
   - subst r.
@@ -568,7 +568,7 @@ have : {in rec, f1 =1 f2}.
     exact: head_row_skew_yam Hinn Hisrow Hskew.
   - rewrite (eq_count (a2 := pred0)); first by rewrite count_pred0.
     by move=> y /=; rewrite eqseq_cons Hneq andbF.
-rewrite eq_in_map /rec /f2 => -> {f1 f2 rec}.
+rewrite eq_in_map /rec /g => -> {f1 g rec}.
 rewrite sumn_count /=.
 apply: (IHrow _ _ Hsize (dominate_tl Hdom) (is_row_consK Hisrow)
                (skew_yam_consK Hinn Hskew)).
@@ -594,9 +594,9 @@ move/eqP; rewrite eqSS => /eqP Hsize Hskew0 Hskew Hincl.
 have Hinn := is_part_skew_yam Hinn0 Hskew0.
 rewrite count_flatten -map_comp.
 set f1 := (X in map X); set rec := (X in map _ X).
-pose f2 := nat_of_bool \o (pred1 (row ++ sol)) \o (@fst (seq nat) (seq nat)).
-have : {in rec, f1 =1 f2}.
-  rewrite /rec /f1 /f2 {rec f1 f2} => [[r shr]] /= Hr.
+pose g := nat_of_bool \o (pred1 (row ++ sol)) \o (@fst (seq nat) (seq nat)).
+have : {in rec, f1 =1 g}.
+  rewrite /rec /f1 /g {rec f1 g} => [[r shr]] /= Hr.
   rewrite count_map.
   case: (altP (r =P (row ++ sol))) => [Heq | /negbTE Hneq] /=.
   - subst r.
@@ -610,7 +610,7 @@ have : {in rec, f1 =1 f2}.
     exact: head_row_skew_yam Hinn0 Hisrow (skew_yam_cat Hskew0 Hskew).
   - rewrite (eq_count (a2 := pred0)); first by rewrite count_pred0.
     by move=> y /=; rewrite eqseq_cons Hneq andbF.
-rewrite eq_in_map /rec /f2 => -> {f1 f2 rec}.
+rewrite eq_in_map /rec /g => -> {f1 g rec}.
 rewrite sumn_count /=.
 apply: (IHsh _ _ _ (is_row_consK Hisrow) Hsize Hskew0 (skew_yam_consK Hinn Hskew)).
 apply: (included_trans _ Hincl).
@@ -639,9 +639,9 @@ move/(_ _ inn inn0 row1 _ (path_sorted Hinn)
         (is_part_consK Hout) Hsize Hskewrec) : IHyamtab => Hrec.
 rewrite /= count_flatten -map_comp subSS -/(outer_shape _ _).
 set f1 := (X in map X); set rec := (X in map _ X).
-pose f2 := nat_of_bool \o (pred1 row1) \o (@fst (seq nat) (seq nat)).
-have : {in rec, f1 =1 f2}.
-  rewrite /rec /f1 /f2 {rec f1 f2} => [[rshift shrshift]] /= Hrshift.
+pose g := nat_of_bool \o (pred1 row1) \o (@fst (seq nat) (seq nat)).
+have : {in rec, f1 =1 g}.
+  rewrite /rec /f1 /g {rec f1 g} => [[rshift shrshift]] /= Hrshift.
   rewrite count_map /=.
   case: (altP (rshift =P row1)) => [Hrow1 | /negbTE Hneq] /=.
   - rewrite Hrow1 (eq_count (a2 := pred1 yamtab)); first last.
@@ -653,14 +653,14 @@ have : {in rec, f1 =1 f2}.
     exact: (skew_yam_catrK Hinnev Hsk1 Hsk2).
   - rewrite (eq_count (a2 := pred0)); first by rewrite count_pred0.
     by move=> y /=; rewrite eqseq_cons Hneq.
-rewrite eq_in_map /rec /f2 => -> {f1 f2 rec Hrec}.
+rewrite eq_in_map /rec /g => -> {f1 g rec Hrec}.
 rewrite !map_comp map_flatten -!map_comp sumn_count.
 rewrite count_flatten -map_comp.
 set f1 := (X in map X); set rowl := (X in map _ X).
-pose f2 := nat_of_bool \o (pred1 (drop (sh0 - inn0) row1)) \o
+pose g := nat_of_bool \o (pred1 (drop (sh0 - inn0) row1)) \o
                        (@fst (seq nat) (seq nat)).
-have : {in rowl, f1 =1 f2}.
-  rewrite /rowl /f1 /f2 {rowl f1 f2} => [[row shrow]] /= Hrow.
+have : {in rowl, f1 =1 g}.
+  rewrite /rowl /f1 /g {rowl f1 g} => [[row shrow]] /= Hrow.
   rewrite count_map /=.
   case: (altP (row =P (drop (sh0 - inn0) row1))) => [Hrow1 | /negbTE Hneq] /=.
   - have Hshrow := yamtab_rowsP Hrow.
@@ -683,7 +683,7 @@ have : {in rowl, f1 =1 f2}.
     case: (leqP sh0 (inn0 + size row1)) => [_ // | /ltnW Hover].
     have:= leq_sub2r inn0 Hover; rewrite addKn => /drop_oversize ->.
     by rewrite drop_oversize.
-rewrite eq_in_map /rowl /f2 => -> {f1 f2 rowl}.
+rewrite eq_in_map /rowl /g => -> {f1 g rowl}.
 rewrite map_comp sumn_count count_map /=.
 move: Hyam; rewrite to_word_cons -{1}(cat_take_drop (sh0 - inn0) row1) catA => Hyam.
 have:= skew_yam_catK Hinnev Hyam => [] [shape Hdrop].

--- a/theories/LRrule/shuffle.v
+++ b/theories/LRrule/shuffle.v
@@ -270,7 +270,7 @@ Definition sfilterleq n := [fun v => map (subn^~ n) (filter (leq n) v)].
 Lemma shiftuK n : cancel (shiftn n) (map (subn^~ n)).
 Proof.
 move=> s; rewrite /shiftn -map_comp.
-rewrite (eq_map (f2 := id)); first by rewrite map_id.
+rewrite (eq_map (g := id)); first by rewrite map_id.
 by move=> i /=; rewrite /= addKn.
 Qed.
 

--- a/theories/LRrule/stdplact.v
+++ b/theories/LRrule/stdplact.v
@@ -283,7 +283,7 @@ rewrite /enum_mem (eq_filter (a2 := mem p)) // -!enumT /= => H.
 apply: (inj_map val_inj).
 rewrite -map_comp (eq_map val2posE).
 rewrite (eq_filter (a2 := mem [set val2pos x | x in p])) //.
-move: H; rewrite (eq_map (f2 := fun i : 'I_(_) => nth (size t) s i)); first last.
+move: H; rewrite (eq_map (g := fun i : 'I_(_) => nth (size t) s i)); first last.
   by move=> i /=; exact: tnth_nth.
 set l := (X in sorted _ X); rewrite -[RHS]/l.
 move=> H; apply: (sorted_eq (leT := leq)).
@@ -324,7 +324,7 @@ apply/and4P; split.
 - apply/forallP => ptmp; apply/implyP => /imsetP [p Hp -> {ptmp}].
   move/(_ p): Hall; rewrite Hp /= /extractpred.
   move/val2pos_enum ->; rewrite -map_comp /=.
-  rewrite (eq_map (f2 := nat_of_ord)); first last.
+  rewrite (eq_map (g := nat_of_ord)); first last.
     move=> i /=; rewrite (tnth_nth (size s)) /=.
     by have:= Hinvst => /linvseqP ->.
   set l := map _ _; have : subseq l [seq val x | x  <- enum 'I_(size s)].

--- a/theories/LRrule/therule.v
+++ b/theories/LRrule/therule.v
@@ -62,7 +62,7 @@ As a corollary we provide the two Pieri rules [Pieri_rowpartn] and
 Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import ssrfun ssrbool eqtype ssrnat seq fintype.
 From mathcomp Require Import tuple finfun finset bigop path ssralg order.
-From SsrMultinomials Require Import mpoly.
+From mathcomp.multinomials Require Import mpoly.
 
 Require Import tools ordcast combclass partition skewpart Yamanouchi ordtype.
 Require Import std tableau stdtab Schensted congr plactic Greene_inv.

--- a/theories/LRrule/therule.v
+++ b/theories/LRrule/therule.v
@@ -318,7 +318,7 @@ rewrite (_ : size_tab _ = d1 + d2); first last.
   rewrite size_join_tab.
   + rewrite size_RS size_std size_hyper_yam sumn_intpartn; congr (_ + _).
     rewrite /size_tab /shape -map_comp.
-    rewrite (eq_map (f2 := size)); last by move=> s /=; rewrite size_map.
+    rewrite (eq_map (g := size)); last by move=> s /=; rewrite size_map.
     rewrite -/(shape _) (shape_skew_reshape Hincl).
     * by rewrite (sumn_diff_shape Hincl) !sumn_intpartn addKn.
     * by rewrite size_std size_yameval sumn_diff_shape_intpartE.
@@ -382,7 +382,7 @@ rewrite !inE /bijLR /= => Hskew.
 case (boolP (is_skew_reshape_tableau P P1 yam)) => [_|] /=; last by rewrite Hskew.
 rewrite /shape /join_tab.
 rewrite !size_map -map_comp.
-rewrite (eq_map (f2 := fun p => size p.1 + size p.2)); first last.
+rewrite (eq_map (g := fun p => size p.1 + size p.2)); first last.
   by move=> i /=; rewrite size_cat.
 rewrite size_zip2 size_skew_reshape.
 rewrite (_ : map size _ = pad 0 (size P) P1); first last.
@@ -393,7 +393,7 @@ rewrite (_ : map size _ = pad 0 (size P) P1); first last.
   by rewrite map_nseq.
 rewrite (_ : map size _ = P / P1); first last.
   rewrite /= -map_comp.
-  rewrite (eq_map (f2 := size)); last by move=> i /=; rewrite size_map.
+  rewrite (eq_map (g := size)); last by move=> i /=; rewrite size_map.
   rewrite -/(shape _) shape_skew_reshape //=.
   by rewrite size_std size_yameval sumn_diff_shape_intpartE.
 rewrite -(size_diff_shape P1 P).
@@ -415,7 +415,7 @@ have -> : shape Q = outer_shape (shape (filter_gt_tab d1 Q)) (shape t).
   have:= stdtabP (stdtabnP Q) => /(join_tab_filter d1) {1}<-.
   rewrite /= /shape /join_tab /pad /=.
   rewrite !size_map -map_comp.
-  rewrite (eq_map (f2 := fun p => size p.1 + size p.2)); first last.
+  rewrite (eq_map (g := fun p => size p.1 + size p.2)); first last.
     by move=> i /=; rewrite size_cat.
   rewrite size_zip2; congr (map _ (zip _ _)).
   move: (size Q) => n.

--- a/theories/MPoly/Cauchy.v
+++ b/theories/MPoly/Cauchy.v
@@ -53,7 +53,7 @@ From mathcomp Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype.
 From mathcomp Require Import tuple bigop path finfun.
 From mathcomp Require Import ssrint rat ssralg ssrnum algC matrix vector.
 
-From SsrMultinomials Require Import ssrcomplements mpoly.
+From mathcomp.multinomials Require Import ssrcomplements mpoly.
 
 Require Import tools partition.
 Require Import antisym Schur_mpoly Schur_altdef sympoly homogsym permcent.

--- a/theories/MPoly/MurnaghanNakayama.v
+++ b/theories/MPoly/MurnaghanNakayama.v
@@ -48,7 +48,7 @@ We provide the following definitions:
 Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype.
 From mathcomp Require Import bigop ssralg ssrint perm fingroup tuple vector rat.
-From SsrMultinomials Require Import ssrcomplements freeg mpoly monalg.
+From mathcomp.multinomials Require Import ssrcomplements freeg mpoly monalg.
 
 Require Import sorted tools ordtype permuted partition skewpart.
 Require Import antisym Schur_mpoly Schur_altdef sympoly homogsym.

--- a/theories/MPoly/Schur_altdef.v
+++ b/theories/MPoly/Schur_altdef.v
@@ -86,7 +86,7 @@ Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import ssrfun ssrbool eqtype ssrnat seq path.
 From mathcomp Require Import choice fintype finfun tuple bigop ssralg ssrint.
 From mathcomp Require Import order finset fingroup perm.
-From SsrMultinomials Require Import ssrcomplements freeg mpoly.
+From mathcomp.multinomials Require Import ssrcomplements freeg mpoly.
 
 Require Import tools combclass ordtype sorted partition tableau.
 Require Import skewpart skewtab antisym Schur_mpoly freeSchur therule.

--- a/theories/MPoly/Schur_altdef.v
+++ b/theories/MPoly/Schur_altdef.v
@@ -1505,9 +1505,9 @@ set mon := (M in 'a_(M)).
 suff /alt_alternate -> : mon i = mon (Ordinal ltan) => //.
   by rewrite -val_eqE /= (gtn_eqF ltai).
 apply/eqP; rewrite {}/mon !mnmE !mpartE //=.
-rewrite !mulmnE !mnm1E eqxx -val_eqE muln1 /= (gtn_eqF ltai) muln0 addn0.
+rewrite !mulmnE !mnm1E eqxx -val_eqE /= (gtn_eqF ltai) mul1n.
 rewrite addnAC -(eqn_add2r (a + i)) {1}(addnC a i) -!addnA.
-rewrite subn1 /= ![(n0 - _) + _]addnA !subnK -?[i <= n0]ltnS //.
+rewrite subn1 /= ![(n0 - _) + _]addnA !subnK -?[i <= n0]ltnS // mul0n add0n.
 rewrite ![(n0 - _) + _]addnA !subnK -?[i <= n0]ltnS //.
 by rewrite ![n0 + _]addnC !addnA [_ + _ + a]addnAC Heq.
 Qed.
@@ -1537,24 +1537,24 @@ rewrite !mulmnE !mnm1E -val_eqE /=.
 have := startrem_leq p d.+1 i; rewrite startremeq => /(_ lt0rem) /= lesmin.
 case: (altP (j =P st)) => [/= eqjst |].
   subst j; apply/eqP.
-  rewrite (nth_add_ribbon_start _ lesmin) cycleij_j // eqxx muln1.
+  rewrite (nth_add_ribbon_start _ lesmin) cycleij_j // eqxx.
   rewrite addnAC -(eqn_add2r (st + i)) {1}(addnC st i) -!addnA.
-  rewrite subn1 /= ![(n0 - _) + _]addnA !subnK -?[i <= n0]ltnS //.
+  rewrite subn1 /= ![(n0 - _) + _]addnA !subnK -?[i <= n0]ltnS // mul1n.
   rewrite ![(n0 - _) + _]addnA !subnK -?[i <= n0]ltnS //.
   rewrite ![n0 + _]addnC !addnA [_ + _ + i]addnAC [_ + _ + st]addnAC.
   by have:= startremE p d.+1 i; rewrite startremeq => ->.
 rewrite neq_ltn => /orP [ltjst | ltstj].
   rewrite cycleij_lt // nth_add_ribbon_lt_start //.
-  by rewrite (gtn_eqF (leq_trans ltjst lesti)) muln0 addn0.
+  by rewrite (gtn_eqF (leq_trans ltjst lesti)) addn0.
 case: (ltnP i j) => [/= ltij | leji].
   rewrite nth_add_ribbon_stop_lt // cycleij_gt //.
-  by rewrite (ltn_eqF ltij) muln0 addn0.
+  by rewrite (ltn_eqF ltij) addn0.
 rewrite -(ltn_predK ltstj) nth_add_ribbon_in //; first last.
   by rewrite (ltn_predK ltstj) ltstj leji.
 rewrite cycleij_in ?ltstj ?leji // inordK; first last.
   by rewrite (ltn_predK ltstj) ltnW.
 case: j ltstj leji => [[|j]//= Hj] _ /gtn_eqF ->.
-by rewrite muln0 addn0 addSnnS subnSK // subn1.
+by rewrite addSnnS subnSK // subn1.
 Qed.
 
 End AlternStraighten.

--- a/theories/MPoly/Schur_mpoly.v
+++ b/theories/MPoly/Schur_mpoly.v
@@ -24,7 +24,7 @@ We give some values for particular partition such as small one, rows and columns
 Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype.
 From mathcomp Require Import tuple finfun finset bigop ssralg order path.
-From SsrMultinomials Require Import ssrcomplements freeg mpoly.
+From mathcomp.multinomials Require Import ssrcomplements freeg mpoly.
 
 Require Import tools ordtype partition tableau.
 

--- a/theories/MPoly/antisym.v
+++ b/theories/MPoly/antisym.v
@@ -49,7 +49,7 @@ Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import ssrfun ssrbool eqtype ssrnat seq path choice.
 From mathcomp Require Import finset fintype finfun tuple bigop ssralg ssrint.
 From mathcomp Require Import fingroup perm zmodp binomial order.
-From SsrMultinomials Require Import ssrcomplements freeg mpoly.
+From mathcomp.multinomials Require Import ssrcomplements freeg mpoly.
 
 Require Import tools permcomp presentSn sorted partition.
 

--- a/theories/MPoly/antisym.v
+++ b/theories/MPoly/antisym.v
@@ -342,7 +342,7 @@ apply/(iffP forallP) => /= [Hanti i j | Htperm s].
   by case: (odd_perm _); rewrite !simplexp // opprK.
 Qed.
 
-Lemma antisym_char2 : (2 \in [char R]) -> symmetric =i antisym.
+Lemma antisym_char2 : (2%nat \in [char R]) -> symmetric =i antisym.
 Proof using.
 move=> Hchar p /=; apply/issymP/isantisymP => H s;
   by rewrite H oppr_char2; first rewrite expr1n scale1r.
@@ -472,7 +472,7 @@ Section AlternIDomain.
 
 Variable n : nat.
 Variable R : idomainType.
-Hypothesis Hchar : ~~ (2 \in [char R]).
+Hypothesis Hchar : ~~ (2%nat \in [char R]).
 
 Local Notation "''a_' k" := (@alternpol n R 'X_[k]).
 Local Notation "m # s" := [multinom m (s i) | i < n].

--- a/theories/MPoly/homogsym.v
+++ b/theories/MPoly/homogsym.v
@@ -79,7 +79,7 @@ From mathcomp Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype.
 From mathcomp Require Import finset path tuple bigop ssralg order.
 From mathcomp Require Import perm fingroup matrix vector.
 From mathcomp Require ssrnum algC.
-From SsrMultinomials Require Import ssrcomplements freeg mpoly.
+From mathcomp.multinomials Require Import ssrcomplements freeg mpoly.
 
 Require Import tools sorted ordtype permuted partition permcent.
 Require Import antisym Schur_mpoly Schur_altdef sympoly.

--- a/theories/MPoly/sympoly.v
+++ b/theories/MPoly/sympoly.v
@@ -88,8 +88,8 @@ Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import ssrfun ssrbool eqtype ssrnat seq choice fintype.
 From mathcomp Require Import tuple finfun finset binomial order.
 From mathcomp Require Import bigop ssralg ssrint path perm fingroup.
-From SsrMultinomials Require Import ssrcomplements freeg mpoly.
-From SsrMultinomials Require monalg.
+From mathcomp.multinomials Require Import ssrcomplements freeg mpoly.
+From mathcomp.multinomials Require monalg.
 
 Require Import sorted tools ordtype permuted partition skewpart composition.
 Require Import Yamanouchi std tableau stdtab skewtab permcent.

--- a/theories/MPoly/sympoly.v
+++ b/theories/MPoly/sympoly.v
@@ -574,9 +574,9 @@ Lemma expUmpartE nv k :
 Proof.
 rewrite rowpartnE.
 apply/mnmP => [[i Hi]]; rewrite /mpart mulmnE !mnmE -val_eqE /=.
-case: k => [|k] /=; first by rewrite mul0n mnmE nth_default.
+case: k => [|k] /=; first by rewrite muln0 mnmE nth_default.
 rewrite mnmE /=;
-by case: i {Hi} => [|i] /=; rewrite ?muln1 // muln0 nth_default.
+by case: i {Hi} => [|i] /=; rewrite ?mul1n // muln0 nth_default.
 Qed.
 
 Lemma expUmpartNE nv k i (P : intpartn k.+1) :
@@ -586,18 +586,18 @@ Proof.
 apply/eqP/andP => [| [/eqP ->{i} /eqP ->{P}]]; last exact: expUmpartE.
 rewrite /mpart; case: leqP => _; first last.
   move/(congr1 (fun mon : 'X_{1..nv.+1} => mon i)).
-  by rewrite mulmnE !mnmE -val_eqE /= eqxx muln1.
+  by rewrite mulmnE !mnmE -val_eqE /= eqxx mul1n.
 case: (altP (i =P ord0)) => [->{i} | neq H]; first split => //.
   apply/eqP/val_inj; rewrite /= rowpartnE.
   case: P H => [[|p0 [|p1 p]]]//=.
     by rewrite addn0 => /andP [/eqP ->].
   rewrite -/(is_part (p1 :: p)) => /and3P [Hsum _ Hpart].
   move/(congr1 (fun mon : 'X_{1..nv.+1} => mon ord0)).
-  rewrite mulmnE !mnmE -val_eqE /= muln1 => Hp0; exfalso.
+  rewrite mulmnE !mnmE -val_eqE /= mul1n => Hp0; exfalso.
   move: Hsum Hpart; rewrite -{}Hp0 -{2}(addn0 k.+1) eqn_add2l.
   by rewrite addn_eq0 => /andP [/eqP -> _] /part_head_non0.
 exfalso; move/(congr1 (fun mon : 'X_{1..nv.+1} => mon ord0)): H.
-rewrite mulmnE !mnmE (negbTE neq) {neq} muln0 /= => Hp0.
+rewrite mulmnE !mnmE (negbTE neq) {neq} mul0n /= => Hp0.
 case: P Hp0 => [[//|p0 p]] Hp /= Hp0.
 by move: Hp; rewrite -{}Hp0 => /andP [_ /part_head_non0].
 Qed.
@@ -1227,7 +1227,7 @@ rewrite /symh_pol mulr_suml linear_sum /=; case: leqP => /= H.
 - pose Ud := (U_(i) *+ d)%MM.
   have Hleq : (Ud <= m)%MM.
     apply/mnm_lepP => j; rewrite mulmnE mnm1E.
-    by case: eqP => /= [<- | _]; rewrite ?muln1 ?muln0.
+    by case: eqP => /= [<- | _]; rewrite ?mul1n ?muln0.
   rewrite andbT -(submK Hleq).
   case: (altP (_ =P _)) => Hdeg /=.
   + move: Hdeg => /eqP; rewrite mdegD mdegMn mdeg1 mul1n eqn_add2r => /eqP Hdeg.
@@ -1246,7 +1246,7 @@ rewrite /symh_pol mulr_suml linear_sum /=; case: leqP => /= H.
 - rewrite andbF big1 // => m' _.
   rewrite mpolyXn -mpolyXD mcoeffX.
   apply/boolRP/eqP/mnmP => /(_ i).
-  rewrite mnmDE mulmnE mnm1E eq_refl muln1 => Habs.
+  rewrite mnmDE mulmnE mnm1E eq_refl mul1n => Habs.
   by move: H; rewrite -Habs ltnNge leq_addl.
 Qed.
 
@@ -1308,13 +1308,13 @@ case: leqP => /= dmi; first last.
   apply/memN_msupp_eq0/negP.
   rewrite (perm_mem (msuppMX _ _)) => /mapP => [/=[mon _]].
   move=> /(congr1 (fun m => m i)) Hmi; move: dmi; rewrite {}Hmi.
-  by rewrite mnmDE mulmnE mnmE eqxx muln1 leqNgt ltnS leq_addr.
+  by rewrite mnmDE mulmnE mnmE eqxx mul1n leqNgt ltnS leq_addr.
 case: leqP => /= dmi2; first last.
   apply/memN_msupp_eq0/negP.
   rewrite (perm_mem (msuppMX _ _)) => /mapP => [/=[mon]].
   rewrite mem_msupp_mesym /mechar => /andP [_ /forallP /= /(_ i) Hmon].
   move=> /(congr1 (fun m => m i)) Hmi; move: dmi2; rewrite {}Hmi.
-  rewrite mnmDE mulmnE mnmE eqxx muln1.
+  rewrite mnmDE mulmnE mnmE eqxx mul1n.
   by rewrite leqNgt !(addSn, ltnS) -(addn1 d) leq_add2l Hmon.
 case: (boolP [forall _, _]) => [/forallP Hall | /=]; first last.
   rewrite negb_forall => /existsP [/= j].
@@ -1323,18 +1323,18 @@ case: (boolP [forall _, _]) => [/forallP Hall | /=]; first last.
   rewrite (perm_mem (msuppMX _ _)) => /mapP => [/=[mon]].
   rewrite mem_msupp_mesym /mechar => /andP [_ /forallP /= /(_ j) Hmon].
   move=> /(congr1 (fun m => m j)) Hmj; move: mj; rewrite {}Hmj.
-  by rewrite mnmDE mulmnE mnmE eq_sym {}neji muln0 add0n leqNgt ltnS Hmon.
+  by rewrite mnmDE mulmnE mnmE eq_sym {}neji mul0n add0n leqNgt ltnS Hmon.
 have {}Hall x : x != i -> m x <= 1 by move=> H; apply: (implyP (Hall x)).
 have leqUm : (U_(i) *+ d <= m)%MM.
   apply/mnm_lepP => j; rewrite mulmnE mnmE.
-  by case: eqP => [<-|]; rewrite ?muln0 // muln1.
+  by case: eqP => [<-|]; rewrite ?mul0n // mul1n.
 rewrite -(submK leqUm) addmC mcoeffMX mcoeff_mesym /mechar.
 move: leqUm => /submK/(congr1 mdeg); rewrite mdegD degm mdegMn mdeg1 mul1n.
 move/eqP; rewrite eqn_add2r => /eqP ->; rewrite eqxx /=.
 case: forallP => // H; exfalso; apply: H => /= j.
 rewrite mnmBE mulmnE mnmE eq_sym.
-case: (altP (_ =P _)) => [->{j} | /Hall]; last by rewrite muln0 subn0.
-by rewrite muln1 leq_subLR addn1.
+case: (altP (_ =P _)) => [->{j} | /Hall]; last by rewrite mul0n subn0.
+by rewrite mul1n leq_subLR addn1.
 Qed.
 
 Lemma mul_ek_p1 (k : nat) :

--- a/theories/SSRcomplements/ordcast.v
+++ b/theories/SSRcomplements/ordcast.v
@@ -33,7 +33,7 @@ Unset Printing Implicit Defensive.
 Lemma enum_cast_ord m n (H : n = m):
   enum 'I_m = [seq cast_ord H i | i <- enum 'I_n].
 Proof.
-by subst m; rewrite /= (eq_map (f2 := id)) ?map_id // => i; apply: val_inj.
+by subst m; rewrite /= (eq_map (g := id)) ?map_id // => i; apply: val_inj.
 Qed.
 
 Lemma nth_ord_ltn i n (H : i < n) x0 : nth x0 (enum 'I_n) i = (Ordinal H).

--- a/theories/SymGroup/Frobenius_char.v
+++ b/theories/SymGroup/Frobenius_char.v
@@ -56,7 +56,7 @@ From mathcomp Require Import ssralg fingroup morphism perm gproduct.
 From mathcomp Require Import rat ssralg ssrint ssrnum algC vector.
 From mathcomp Require Import mxrepresentation classfun character.
 
-From SsrMultinomials Require Import mpoly.
+From mathcomp.multinomials Require Import mpoly.
 Require Import sorted ordtype tools partition antisym sympoly homogsym Cauchy
         Schur_altdef stdtab therule.
 Require Import permcomp cycletype towerSn permcent reprSn unitriginv.

--- a/theories/SymGroup/cycletype.v
+++ b/theories/SymGroup/cycletype.v
@@ -337,7 +337,7 @@ Lemma cycle_type_conjg s a : cycle_type (s ^ a)%g = cycle_type s.
 Proof using.
 apply esym; apply val_inj => /=.
 rewrite porbits_conjg; apply/perm_sortP => //=.
-rewrite [X in perm_eq X _](eq_map (f2 := fun X : {set T} => #|a @: X|)); first last.
+rewrite [X in perm_eq X _](eq_map (g := fun X : {set T} => #|a @: X|)); first last.
   by move => x;  apply esym; apply card_imset; exact: perm_inj.
 rewrite (map_comp (fun x => #{x})); apply: perm_map.
 apply uniq_perm.

--- a/theories/SymGroup/presentSn.v
+++ b/theories/SymGroup/presentSn.v
@@ -282,7 +282,7 @@ have /IHn{IHn} Hcount : is_code_of_size n c.
   rewrite /is_code_of_size Hsz eq_refl andbT.
   exact: (is_code_rconsK Hcode).
 rewrite count_flatten -map_comp -/enum_codesz.
-rewrite (eq_map (f2 := fun i => i == cn : nat)); first last.
+rewrite (eq_map (g := fun i => i == cn : nat)); first last.
   move=> i /=; rewrite count_map /=.
   case (altP (i =P cn)) => [Heq | /negbTE Hneq].
   + subst i; rewrite (eq_count (a2 := xpred1 c)); first exact: Hcount.
@@ -333,7 +333,7 @@ Proof.
 rewrite factE /= cardE -(size_map val) enum_codeszE.
 elim: n => [//=| n IHn].
 rewrite size_flatten -/enum_codesz /shape -map_comp.
-rewrite (eq_map (f2 := fun => fact_rec n)); first last.
+rewrite (eq_map (g := fun => fact_rec n)); first last.
   by move=> i /=; rewrite size_map.
 by rewrite sumnE big_map big_const_seq count_predT size_iota iter_addn_0 mulnC.
 Qed.

--- a/theories/SymGroup/reprSn.v
+++ b/theories/SymGroup/reprSn.v
@@ -234,7 +234,7 @@ Proof.
 case: n => // n; rewrite ltnS => Hn.
 apply/negP=> /eqP/cfunP /(_ 's_0)/eqP.
 rewrite cfunE cfun1E inE /= (odd_eltr Hn) /= expr1 -addr_eq0 -mulr2n.
-by have := Cchar; rewrite charf0P => /(_ 2) ->.
+by have := Cchar; rewrite charf0P => /(_ 2%nat) ->.
 Qed.
 
 Lemma triv_sign_not_sim n :
@@ -276,7 +276,7 @@ Qed.
 
 (** * Representations of the symmetric Group for n=2  *)
 
-Lemma NirrS2 : Nirr 'SG_2 = 2.
+Lemma NirrS2 : Nirr 'SG_2 = 2%nat.
 Proof using. by rewrite NirrSn card_intpartn. Qed.
 
 Lemma cast_IirrS2 (i : Iirr 'SG_2) :


### PR DESCRIPTION
This PR updates the theory files in `theories` and `3rdparty` to build this project with following versions of its dependencies:
Coq: 8.16.1
mathcomp-1.16.0
finmap-1.5.2
mathcomp-multinomials: 1.5.6